### PR TITLE
Fix get_all_employees() when employeeID == '0'

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -357,7 +357,10 @@ class PyBambooHR(object):
             users = {}
             # get all employees (doesn't get whom don't have activity)
             for u in self.get_meta_users().values():
-                users[str(u['employeeId'])] = True if u['status']=='enabled' else False
+                # PyBambooHR.get_employee() fails when employeeID == '0',
+                # so skipping such users altogether:
+                if u['employeeId'] != '0':
+                    users[str(u['employeeId'])] = True if u['status']=='enabled' else False
             # get all enabled employees (included whom don't have activity, but are enabled)
             for u in self.get_employee_directory():
                 users[u['id']] = True


### PR DESCRIPTION
For certain types of users, the BambooHR API may return {'employeeID': '0'}
when calling PyBambooHR.get_meta_users()., BambooHR API returns 404 when reading
employee data with such ID which causes first PyBambooHR.get_employee() and
ultimately PyBambooHR.get_all_employees() to fail with
requests.exceptions.HTTPError.

Setting disabledUsers parameter to False does not help since such users may
still be enabled.

With this fix, get_all_employees() simply excludes altogether any users with
employeeID == '0'.

Warning: Although the method should still do what is promises, i.e. return a
dictionary of all _employees_, there might be some side effects that I am not
aware of.